### PR TITLE
UV-911 bugfix: 

### DIFF
--- a/app/src/app/data/contact/contact.selectors.ts
+++ b/app/src/app/data/contact/contact.selectors.ts
@@ -4,12 +4,15 @@ import { State } from '@app/app-reducer';
 import { getMergedRoute } from '@data/router/router.selectors';
 
 
+
 export const selectContacts = (state: State) => state.contact.contacts;
 
 export const getContacts = createSelector(
   selectContacts,
-  (contacts: { [id: string ]: ContactInterfaces.Contact }) => {
-    return Object.values(contacts).map((contact) => ({ ...contact }));
+  getMergedRoute,
+  (contacts: { [id: string ]: ContactInterfaces.Contact }, mergedRoute) => {
+   // return Object.values(contacts).map((contact) => ({ ...contact }));
+   return Object.values(contacts).filter(contact => contact.assetId === mergedRoute.params.assetId);
   }
 );
 

--- a/app/src/app/data/contact/contact.selectors.ts
+++ b/app/src/app/data/contact/contact.selectors.ts
@@ -7,11 +7,10 @@ import { getMergedRoute } from '@data/router/router.selectors';
 
 export const selectContacts = (state: State) => state.contact.contacts;
 
-export const getContacts = createSelector(
+export const getContactsOnAsset = createSelector(
   selectContacts,
   getMergedRoute,
   (contacts: { [id: string ]: ContactInterfaces.Contact }, mergedRoute) => {
-   // return Object.values(contacts).map((contact) => ({ ...contact }));
    return Object.values(contacts).filter(contact => contact.assetId === mergedRoute.params.assetId);
   }
 );

--- a/app/src/app/modules/asset/pages/show/show.component.ts
+++ b/app/src/app/modules/asset/pages/show/show.component.ts
@@ -36,7 +36,7 @@ export class ShowPageComponent implements OnInit, OnDestroy {
       }
     });
     this.mobileTerminals$ = this.store.select(MobileTerminalSelectors.getMobileTerminalsForUrlAsset);
-    this.contacts$ = this.store.select(ContactSelectors.getContacts);
+    this.contacts$ = this.store.select(ContactSelectors.getContactsOnAsset);
   }
 
   mapDispatchToProps() {


### PR DESCRIPTION
Stop contacts from being readable when you change assets without refresh of page